### PR TITLE
User/yreda/reorder compilation and python script fixes

### DIFF
--- a/movo_common/movo_ros/CMakeLists.txt
+++ b/movo_common/movo_ros/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(movo_ros)
 
+find_package(catkin REQUIRED COMPONENTS roslaunch rospy dynamic_reconfigure)
+
 ## Uncomment if the package has a setup.py
 catkin_python_setup()
-
-find_package(catkin REQUIRED COMPONENTS roslaunch rospy dynamic_reconfigure)
 
 generate_dynamic_reconfigure_options(cfg/movo.cfg)
 

--- a/movo_common/movo_ros/src/movo/movo_comm.py
+++ b/movo_common/movo_ros/src/movo/movo_comm.py
@@ -33,17 +33,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  \Platform: Linux/ROS Indigo
 --------------------------------------------------------------------"""
-from system_defines import *
-from utils import *
+from movo.system_defines import *
+from movo.utils import *
 from movo_msgs.msg import *
 from geometry_msgs.msg import Twist
 from movo_ros.cfg import movoConfig
 from dynamic_reconfigure.server import Server
 from dynamic_reconfigure.client import Client
 from dynamic_reconfigure.msg import Config
-from io_eth import IoEthThread
-from movo_data_classes import MOVO_DATA
-from movo_linear_actuator import LinearActuator
+from movo.io_eth import IoEthThread
+from movo.movo_data_classes import MOVO_DATA
+from movo.movo_linear_actuator import LinearActuator
 import multiprocessing
 import rospy
 import select

--- a/movo_common/movo_ros/src/movo/movo_data_classes.py
+++ b/movo_common/movo_ros/src/movo/movo_data_classes.py
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  \Platform: Linux/ROS Indigo
 --------------------------------------------------------------------"""
-from utils import convert_u32_to_float,numToDottedQuad
+from movo.utils import convert_u32_to_float,numToDottedQuad
 from movo_msgs.msg import *
 from nav_msgs.msg import Odometry
 from geometry_msgs.msg import PoseWithCovarianceStamped

--- a/movo_common/movo_ros/src/movo/movo_linear_actuator.py
+++ b/movo_common/movo_ros/src/movo/movo_linear_actuator.py
@@ -33,10 +33,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  \Platform: Linux/ROS Indigo
 --------------------------------------------------------------------"""
-from system_defines import *
-from utils import *
+from movo.system_defines import *
+from movo.utils import *
 from movo_msgs.msg import LinearActuatorCmd
-from io_eth import IoEthThread
+from movo.io_eth import IoEthThread
 import multiprocessing
 import re
 import os

--- a/movo_common/movo_ros/src/movo/utils.py
+++ b/movo_common/movo_ros/src/movo/utils.py
@@ -36,9 +36,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import struct
 import socket
 import math
-from crc32 import calc_crc32, valid_crc32
+from movo.crc32 import calc_crc32, valid_crc32
 import array
-from system_defines import *
+from movo.system_defines import *
 import timeit
 
 """


### PR DESCRIPTION
the reordering fixes a compilation error i get when building on the movo itself
the python changes fix import errors seen. likely needed bc python 3 imports are different from python 2