### PR TITLE
User/le2tang/compiler warnings

### DIFF
--- a/movo_common/movo_navigation/movo_assisted_teleop/CMakeLists.txt
+++ b/movo_common/movo_navigation/movo_assisted_teleop/CMakeLists.txt
@@ -29,7 +29,7 @@ message("Assisted telop catkin_LIBRARY_DIRS: " ${catkin_LIBRARY_DIRS})
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS}
-  DEPENDS Eigen
+  DEPENDS EIGEN3
 )
 
 add_executable(movo_assisted_teleop src/movo_assisted_teleop.cpp)

--- a/movo_common/movo_navigation/movo_assisted_teleop/CMakeLists.txt
+++ b/movo_common/movo_navigation/movo_assisted_teleop/CMakeLists.txt
@@ -20,7 +20,7 @@ set(THIS_PACKAGE_ROS_DEPS
 )
 
 find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS} ${Eigen_LIBRARY_DIRS})

--- a/movo_common/movo_third_party/simple_grasping/CMakeLists.txt
+++ b/movo_common/movo_third_party/simple_grasping/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED grasp_msgs
     shape_msgs
     tf
 )
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 link_directories(
   ${catkin_LIBRARY_DIRS}

--- a/movo_robot/movo_sensor_filters/ira_laser_tools/src/laserscan_multi_merger.cpp
+++ b/movo_robot/movo_sensor_filters/ira_laser_tools/src/laserscan_multi_merger.cpp
@@ -196,7 +196,7 @@ void LaserscanMerger::scanCallback(const sensor_msgs::LaserScan::ConstPtr& scan,
 
 		for(int i=1; i<clouds_modified.size(); ++i)
 		{
-			pcl::concatenatePointCloud(merged_cloud, clouds[i], merged_cloud);
+			pcl::concatenate(merged_cloud, clouds[i], merged_cloud);
 			clouds_modified[i] = false;
 		}
 	

--- a/movo_robot/movo_sensor_filters/range_sensor_filters/CMakeLists.txt
+++ b/movo_robot/movo_sensor_filters/range_sensor_filters/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED COMPONENTS roscpp tf filters laser_geometry pcl_ros
 
 catkin_package(
     DEPENDS 
-    CATKIN-DEPENDS roscpp tf filters laser_geometry pcl_ros geometry_msgs sensor_msgs message_filters
+    CATKIN_DEPENDS roscpp tf filters laser_geometry pcl_ros geometry_msgs sensor_msgs message_filters
     INCLUDE_DIRS include
     LIBRARIES range_sensor_filters
 )

--- a/movo_simulation/movo_gazebo_plugins/gazebo_force_based_move/CMakeLists.txt
+++ b/movo_simulation/movo_gazebo_plugins/gazebo_force_based_move/CMakeLists.txt
@@ -42,7 +42,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    DEPENDS gazebo
+    DEPENDS GAZEBO
     CATKIN_DEPENDS roscpp std_msgs geometry_msgs nav_msgs tf message_runtime
     INCLUDE_DIRS include
     LIBRARIES

--- a/movo_simulation/movo_gazebo_plugins/gazebo_grasp_plugin/CMakeLists.txt
+++ b/movo_simulation/movo_gazebo_plugins/gazebo_grasp_plugin/CMakeLists.txt
@@ -31,7 +31,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES gazebo_grasp_fix
   CATKIN_DEPENDS gazebo_ros geometry_msgs roscpp std_msgs
-  DEPENDS gazebo 
+  DEPENDS GAZEBO 
 )
 
 ###########

--- a/movo_simulation/movo_gazebo_plugins/gazebo_grasp_plugin/src/GazeboGraspFix.cpp
+++ b/movo_simulation/movo_gazebo_plugins/gazebo_grasp_plugin/src/GazeboGraspFix.cpp
@@ -584,11 +584,11 @@ void GazeboGraspFix::OnUpdate() {
 
             // Get transform for currLinkWorldPose as matrix
             ignition::math::Matrix4d worldToLink(currLinkWorldPose.Rot());
-            worldToLink.Translate(currLinkWorldPose.Pos());
+            worldToLink.SetTranslation(currLinkWorldPose.Pos());
 
             // Get the transform from collision link to contact point
             ignition::math::Matrix4d linkToContact=ignition::math::Matrix4d::Identity;
-            linkToContact.Translate(relContactPos);
+            linkToContact.SetTranslation(relContactPos);
                     
             // the current world position of the contact point right now is:
             ignition::math::Matrix4d _currContactWorldPose=worldToLink*linkToContact;
@@ -770,12 +770,12 @@ void GazeboGraspFix::OnContact(const ConstContactsPtr &_msg)
 
             // To find out the collision point relative to the Link's local coordinate system, first get the Poses as 4x4 matrices
             ignition::math::Matrix4d worldToLink(linkWorldPose.Rot());
-            worldToLink.Translate(linkWorldPose.Pos());
+            worldToLink.SetTranslation(linkWorldPose.Pos());
             
             ignition::math::Matrix4d worldToContact=ignition::math::Matrix4d::Identity;
             //we can assume that the contact has identity rotation because we don't care about its orientation.
             //We could always set another rotation here too.
-            worldToContact.Translate(avgPos);
+            worldToContact.SetTranslation(avgPos);
 
             // now, worldToLink * contactInLocal = worldToContact
             // hence, contactInLocal = worldToLink.Inv * worldToContact
@@ -803,7 +803,7 @@ void GazeboGraspFix::OnContact(const ConstContactsPtr &_msg)
             // now, get the pose of the object and compute it's relative position to the collision surface.
             ignition::math::Pose3d objWorldPose = objCollision->GetLink()->WorldPose();
             ignition::math::Matrix4d worldToObj(objWorldPose.Rot());
-            worldToObj.Translate(objWorldPose.Pos());
+            worldToObj.SetTranslation(objWorldPose.Pos());
     
             ignition::math::Matrix4d objInLocal = worldToLinkInv * worldToObj;
             ignition::math::Vector3d objPosInLocal = objInLocal.Translation();


### PR DESCRIPTION
Fix compiler warnings generated by catkin_make

1. Replace "Eigen" with "Eigen3" as a dependency
2. Fix capitalization to find packages in the correct directories
3. Replace deprecated ignition .Translate() function with .SetTranslation(). Name change only based on documentation.
4. Replace pcl::concatenatePointCloud() function with pcl::concatenate(). No apparent differences in functionality.