### PR TITLE
sim: increased mass of base in urdf bc robot tips over in sim

### DIFF
--- a/movo_common/movo_description/urdf/movo_components/movo_base.urdf.xacro
+++ b/movo_common/movo_description/urdf/movo_components/movo_base.urdf.xacro
@@ -48,7 +48,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         
         <link name="base_chassis_link">
 			<inertial>
-				<mass value="44.2877" />
+                <!-- The robot tips over in simulation bc the COM is too high -->
+                <!-- We bring the COM down by increasing mass of the base -->
+                <!-- This new mass was found to work well empirically -->
+                <!-- <mass value="44.2877" /> -->
+				<mass value="80.2877" />
 				<origin xyz="-0.009506 -0.013039 0.032319" />
 				<inertia ixx="0.000165"  ixy="0" ixz="0"
                          iyx="0"  iyy="0.000559" iyz="0"


### PR DESCRIPTION
In simulation, the robot tips over when driving forward. At very slow speeds, the robot does not tip over, but oscillates (rocks back and forth) when stopping or starting. At higher speeds, it face-plants. This is due to the high center of mass of the robot in simulation. This is obviously not a problem IRL. From our experience with the Movo, there is no risk of it tipping over.

2 possible solutions:
1. Limit driving speed in simulation -> would be pretty annoying. makes development slow.
2. Bring the center of mass down by increasing the mass of the base.

Can anyone think of any unintended consequences of this change? Perhaps navigation will require different max_vel and min_vel in sim rather than irl? i dont think arms or perception are affected.