### PR TITLE
movo2 interface should be br0 not enp0s25

### DIFF
--- a/movo_network/movo_network_config.bash
+++ b/movo_network/movo_network_config.bash
@@ -19,7 +19,7 @@ if [ "$HOSTNAME" = movo1 ]; then
     export ROS_IP=$(ip -4 address show $ROBOT_NETWORK | grep 'inet' | sed 's/.*inet \([0-9\.]\+\).*/\1/' | head -n 1)
     export ROS_MASTER_URI=http://movo2:11311/
 elif [ "$HOSTNAME" = movo2 ]; then
-    export ROBOT_NETWORK=enp0s25
+    export ROBOT_NETWORK=br0
     export ROS_IP=$(ip -4 address show $ROBOT_NETWORK | grep 'inet' | sed 's/.*inet \([0-9\.]\+\).*/\1/' | head -n 1)
     export ROS_MASTER_URI=http://movo2:11311/
 else


### PR DESCRIPTION
ROS_IP env var is not set correctly on movo2. this is bc the wrong interface is set. Previously the ROS_IP would be empty. this resulted in a runtime error by movo1 (some socket error) and a warning on movo2

This is not a problem on movo1

![image](https://user-images.githubusercontent.com/52610118/211373853-52dd0435-1e01-42ef-bbd4-ff28357e0c62.png)


![image](https://user-images.githubusercontent.com/52610118/211374128-714f16fe-e376-4802-9c2d-3d475b64ca77.png)
