### PR TITLE
remove echo in network bash script

### DIFF
--- a/movo_network/movo_network_config.bash
+++ b/movo_network/movo_network_config.bash
@@ -42,7 +42,6 @@ else
             export ROS_MASTER_URI=http://movo2:11311/
         fi
     else
-        echo "No interface on the movo network, def sim settings"
         #No interface on the movo network; default simulation settings
         export ROBOT_NETWORK=lo
         export ROS_IP=$(ip -4 address show $ROBOT_NETWORK | grep 'inet' | sed 's/.*inet \([0-9\.]\+\).*/\1/')


### PR DESCRIPTION
@le2tang u added this echo statement in [this pr](https://github.com/nightingale-project/kinova-movo/pull/16). Was it just a debug print or did u think it was useful?

the issue with the echo statement is that it gets printed every time we source the directory when using sim. when using sim, we fall into the 3rd case and the robot_iface env var is blank so we print ur debug print every time. I think the print is unncessary and cluters the terminal