### PR TITLE
comment out moveit launch in movo2.launch

### DIFF
--- a/movo_robot/movo_bringup/launch/movo2.launch
+++ b/movo_robot/movo_bringup/launch/movo2.launch
@@ -32,10 +32,12 @@
         name="perception_bringup" output="screen"/>
 
 
-    <!-- Moveit bringup-->
+    <!-- Moveit bringup
+    Ben TODO uncomment
     <node pkg="si_utils" type="timed_roslaunch"
         args="20 movo_bringup movo_moveit.launch local:=true"
         name="movo_moveit_bringup" output="screen"/> 
+    -->
 
 
 </launch>


### PR DESCRIPTION
launching movo_system.launch on master results in errors. specifically, the errors arrive from movo2.launch and are related to arms. the error states that some arm controllers are not available which is expected since movo1.launch does not launch arms (yet see https://github.com/nightingale-project/kinova-movo/pull/33) .
