### PR TITLE
Users/felix/configurable camera scan merge

### DIFF
--- a/movo_robot/movo_bringup/launch/sensors/movo_sensors.launch
+++ b/movo_robot/movo_bringup/launch/sensors/movo_sensors.launch
@@ -41,13 +41,26 @@
         <param name="timelimit" type="int" value="5" />
     </node>
         
+    <arg name="merge_camera_scan" value="$(optenv MERGE_CAMERA_SCAN false)"/>
+ 
+    <group if="$(arg merge_camera_scan)">
+    <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen"> 
+        <param name="destination_frame" value="base_link"/>
+        <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
+        <param name="scan_destination_topic" value="/movo/scan_multi"/>
+        <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan /movo/camera_scan"/>
+    </node>
+    </group>
+
+    <group unless="$(arg merge_camera_scan)">
     <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen">
         <param name="destination_frame" value="base_link"/>
         <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
         <param name="scan_destination_topic" value="/movo/scan_multi"/>
-	<param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan"/>
+        <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan"/>
     </node>
-    
+    </group>
+
     <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter" clear_params="true" respawn="true">
         <remap from="scan" to="/movo/scan_multi" />
         <remap from="scan_filtered" to="/movo/base_scan_filtered" />
@@ -56,7 +69,7 @@
         <rosparam command="load" 
             file="$(find movo_bringup)/launch/sensors/config/laser_scan_filter.yaml" />
     </node>
-    
+
     <node pkg="laser_scan_matcher" type="laser_scan_matcher_node" name="laser_scan_matcher_node" output="screen" if="$(optenv MOVO_ENABLE_LSM false)" >
         <rosparam command="load" 
                 file="$(find movo_bringup)/launch/sensors/config/laser_scan_matcher.yaml" />

--- a/movo_robot/movo_bringup/launch/sensors/movo_sensors.launch
+++ b/movo_robot/movo_bringup/launch/sensors/movo_sensors.launch
@@ -41,14 +41,6 @@
         <param name="timelimit" type="int" value="5" />
     </node>
         
- 
-    <node pkg="ira_laser_tools" name="laserscan_multi_merger_camera" type="laserscan_multi_merger" output="screen"> 
-        <param name="destination_frame" value="base_link"/>
-        <param name="cloud_destination_topic" value="/movo/merged_cloud_camera"/>
-        <param name="scan_destination_topic" value="/movo/scan_multi_camera"/>
-        <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan /movo/camera_scan"/>
-    </node>
-
     <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen">
         <param name="destination_frame" value="base_link"/>
         <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
@@ -64,16 +56,6 @@
         <rosparam command="load" 
             file="$(find movo_bringup)/launch/sensors/config/laser_scan_filter.yaml" />
     </node>
-
-    <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter_camera" clear_params="true" respawn="true">
-        <remap from="scan" to="/movo/scan_multi_camera" />
-        <remap from="scan_filtered" to="/movo/base_scan_filtered_camera" />
-        <param name="target_frame" value="base_link" />
-        <param name="high_fidelity" value="true" />
-        <rosparam command="load" 
-            file="$(find movo_bringup)/launch/sensors/config/laser_scan_filter.yaml" />
-    </node>
-
 
     <node pkg="laser_scan_matcher" type="laser_scan_matcher_node" name="laser_scan_matcher_node" output="screen" if="$(optenv MOVO_ENABLE_LSM false)" >
         <rosparam command="load" 

--- a/movo_robot/movo_bringup/launch/sensors/movo_sensors.launch
+++ b/movo_robot/movo_bringup/launch/sensors/movo_sensors.launch
@@ -41,25 +41,20 @@
         <param name="timelimit" type="int" value="5" />
     </node>
         
-    <arg name="merge_camera_scan" value="$(optenv MERGE_CAMERA_SCAN false)"/>
  
-    <group if="$(arg merge_camera_scan)">
-    <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen"> 
+    <node pkg="ira_laser_tools" name="laserscan_multi_merger_camera" type="laserscan_multi_merger" output="screen"> 
         <param name="destination_frame" value="base_link"/>
-        <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
-        <param name="scan_destination_topic" value="/movo/scan_multi"/>
+        <param name="cloud_destination_topic" value="/movo/merged_cloud_camera"/>
+        <param name="scan_destination_topic" value="/movo/scan_multi_camera"/>
         <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan /movo/camera_scan"/>
     </node>
-    </group>
 
-    <group unless="$(arg merge_camera_scan)">
     <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen">
         <param name="destination_frame" value="base_link"/>
         <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
         <param name="scan_destination_topic" value="/movo/scan_multi"/>
         <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan"/>
     </node>
-    </group>
 
     <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter" clear_params="true" respawn="true">
         <remap from="scan" to="/movo/scan_multi" />
@@ -69,6 +64,16 @@
         <rosparam command="load" 
             file="$(find movo_bringup)/launch/sensors/config/laser_scan_filter.yaml" />
     </node>
+
+    <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter_camera" clear_params="true" respawn="true">
+        <remap from="scan" to="/movo/scan_multi_camera" />
+        <remap from="scan_filtered" to="/movo/base_scan_filtered_camera" />
+        <param name="target_frame" value="base_link" />
+        <param name="high_fidelity" value="true" />
+        <rosparam command="load" 
+            file="$(find movo_bringup)/launch/sensors/config/laser_scan_filter.yaml" />
+    </node>
+
 
     <node pkg="laser_scan_matcher" type="laser_scan_matcher_node" name="laser_scan_matcher_node" output="screen" if="$(optenv MOVO_ENABLE_LSM false)" >
         <rosparam command="load" 

--- a/movo_simulation/movo_gazebo/launch/movo.launch
+++ b/movo_simulation/movo_gazebo/launch/movo.launch
@@ -58,26 +58,30 @@
     
     <node pkg="movo_gazebo" name="sim_odometry" type="sim_odometry" output="screen"/>
     
-    <arg name="merge_camera_scan" value="$(optenv MERGE_CAMERA_SCAN false)"/>
  
-    <group if="$(arg merge_camera_scan)">
-    <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen"> 
+    <node pkg="ira_laser_tools" name="laserscan_multi_merger_camera" type="laserscan_multi_merger" output="screen"> 
         <param name="destination_frame" value="base_link"/>
-        <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
-        <param name="scan_destination_topic" value="/movo/scan_multi"/>
+        <param name="cloud_destination_topic" value="/movo/merged_cloud_camera"/>
+        <param name="scan_destination_topic" value="/movo/scan_multi_camera"/>
         <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan /movo/camera_scan"/>
     </node>
-    </group>
 
-    <group unless="$(arg merge_camera_scan)">
     <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen">
         <param name="destination_frame" value="base_link"/>
         <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
         <param name="scan_destination_topic" value="/movo/scan_multi"/>
         <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan"/>
     </node>
-    </group>
 
+    <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter_camera" clear_params="true" respawn="true">
+        <remap from="scan" to="/movo/scan_multi_camera" />
+        <remap from="scan_filtered" to="/movo/base_scan_filtered_camera" />
+        <param name="target_frame" value="base_link" />
+        <param name="high_fidelity" value="true" />
+        <rosparam command="load" 
+            file="$(find movo_bringup)/launch/sensors/config/laser_scan_filter.yaml" />
+    </node>
+ 
     <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter" clear_params="true" respawn="true">
         <remap from="scan" to="/movo/scan_multi" />
         <remap from="scan_filtered" to="/movo/base_scan_filtered" />

--- a/movo_simulation/movo_gazebo/launch/movo.launch
+++ b/movo_simulation/movo_gazebo/launch/movo.launch
@@ -58,12 +58,26 @@
     
     <node pkg="movo_gazebo" name="sim_odometry" type="sim_odometry" output="screen"/>
     
+    <arg name="merge_camera_scan" value="$(optenv MERGE_CAMERA_SCAN false)"/>
+ 
+    <group if="$(arg merge_camera_scan)">
+    <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen"> 
+        <param name="destination_frame" value="base_link"/>
+        <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
+        <param name="scan_destination_topic" value="/movo/scan_multi"/>
+        <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan /movo/camera_scan"/>
+    </node>
+    </group>
+
+    <group unless="$(arg merge_camera_scan)">
     <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen">
         <param name="destination_frame" value="base_link"/>
         <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
         <param name="scan_destination_topic" value="/movo/scan_multi"/>
-	<param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan"/>
+        <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan"/>
     </node>
+    </group>
+
     <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter" clear_params="true" respawn="true">
         <remap from="scan" to="/movo/scan_multi" />
         <remap from="scan_filtered" to="/movo/base_scan_filtered" />

--- a/movo_simulation/movo_gazebo/launch/movo.launch
+++ b/movo_simulation/movo_gazebo/launch/movo.launch
@@ -58,14 +58,6 @@
     
     <node pkg="movo_gazebo" name="sim_odometry" type="sim_odometry" output="screen"/>
     
- 
-    <node pkg="ira_laser_tools" name="laserscan_multi_merger_camera" type="laserscan_multi_merger" output="screen"> 
-        <param name="destination_frame" value="base_link"/>
-        <param name="cloud_destination_topic" value="/movo/merged_cloud_camera"/>
-        <param name="scan_destination_topic" value="/movo/scan_multi_camera"/>
-        <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan /movo/camera_scan"/>
-    </node>
-
     <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen">
         <param name="destination_frame" value="base_link"/>
         <param name="cloud_destination_topic" value="/movo/merged_cloud"/>
@@ -73,15 +65,6 @@
         <param name="laserscan_topics" value ="/movo/$(optenv LASER1_PREFIX front)_scan /movo/$(optenv LASER2_PREFIX rear)_scan"/>
     </node>
 
-    <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter_camera" clear_params="true" respawn="true">
-        <remap from="scan" to="/movo/scan_multi_camera" />
-        <remap from="scan_filtered" to="/movo/base_scan_filtered_camera" />
-        <param name="target_frame" value="base_link" />
-        <param name="high_fidelity" value="true" />
-        <rosparam command="load" 
-            file="$(find movo_bringup)/launch/sensors/config/laser_scan_filter.yaml" />
-    </node>
- 
     <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="movo_laser_filter" clear_params="true" respawn="true">
         <remap from="scan" to="/movo/scan_multi" />
         <remap from="scan_filtered" to="/movo/base_scan_filtered" />


### PR DESCRIPTION
Added a second node for laser scan merger to remove dependency on camera scan. Now there is 1 scan that includes the camera scan data (suffix "_camera") and one node for combining just front and rear.